### PR TITLE
#minor Sticky version configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ _NOTE: set the fetch-depth for `actions/checkout@v2` or newer to be sure you ret
   - `full`: attempt to show all history, does not work on rebase and squash due missing HEAD [should be deprecated in v2 is breaking many workflows]
   - `last`: show the single last commit
   - `compare`: show all commits since previous repo tag number
+- **MAJOR_STICKY_VERSION** _(optional)_ - Set the `X` part of `X.Y.Z` version to be constant
+- **MINOR_STICKY_VERSION** _(optional)_ - Set the `Y` part of `X.Y.Z` version to be constant. Should be used with `MAJOR_STICKY_VERSION`
 
 ### Outputs
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,6 +21,8 @@ minor_string_token=${MINOR_STRING_TOKEN:-#minor}
 patch_string_token=${PATCH_STRING_TOKEN:-#patch}
 none_string_token=${NONE_STRING_TOKEN:-#none}
 branch_history=${BRANCH_HISTORY:-compare}
+major_sticky_version=${MAJOR_STICKY_VERSION}
+minor_sticky_version=${MINOR_STICKY_VERSION}
 # since https://github.blog/2022-04-12-git-security-vulnerability-announced/ runner uses?
 git config --global --add safe.directory /github/workspace
 
@@ -55,7 +57,7 @@ fi
 setOutput() {
     echo "${1}=${2}" >> "${GITHUB_OUTPUT}"
 }
-
+pwd
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 
 pre_release="$prerelease"
@@ -77,8 +79,35 @@ echo "pre_release = $pre_release"
 # fetch tags
 git fetch --tags
 
-tagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+$"
-preTagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+(-$suffix\.[0-9]+)$"
+tagFmt=''
+if [ -z "$major_sticky_version" ]
+then
+  tagFmt='[0-9]+'
+else
+  tagFmt="$major_sticky_version"
+fi
+
+if [ -z "$minor_sticky_version" ]
+then
+  tagFmt="$tagFmt\.[0-9]+"
+else
+  tagFmt="$tagFmt\.$minor_sticky_version"
+fi
+
+preTagFmt="$tagFmt\.[0-9]+(-$suffix\.[0-9]+)$"
+tagFmt="$tagFmt\.[0-9]+$"
+
+if $with_v
+then
+  tagFmt="^v$tagFmt"
+  preTagFmt="^v$preTagFmt"
+else
+  tagFmt="^$tagFmt"
+  preTagFmt="^$preTagFmt"
+fi
+
+echo "tagFmt = $tagFmt"
+echo "preTagFmt = $preTagFmt"
 
 # get the git refs
 git_refs=

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,7 +57,6 @@ fi
 setOutput() {
     echo "${1}=${2}" >> "${GITHUB_OUTPUT}"
 }
-pwd
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 
 pre_release="$prerelease"


### PR DESCRIPTION
# Summary of changes

Two configuration options have appeared: `MAJOR_STICKY_VERSION` and `MINOR_STICKY_VERSION` .

They allow to fix first two numbers in the version to certain numbers. 

No matter what the commit message is, the fixed numbers stay the same as configured.

## Breaking Changes

NO. Shouldn't be present.

## How changes have been tested

- local tests provided using a set of dry runs.

## List any unknowns

The code should be reviewed to check if something is missing.